### PR TITLE
Fixes #32, linking containers is obsolete in version 2 docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Docker-symfony gives you everything you need for developing Symfony application.
         ```yml
         # path/to/your/symfony-project/app/config/parameters.yml
         parameters:
-            database_host: mysqldb
+            database_host: db
         ```
 
     2. Composer install & create database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
         build: php7-fpm
         ports:
             - 9000:9000
-        links:
-            - db:mysqldb
         volumes:
             - ${SYMFONY_APP_PATH}:/var/www/symfony
             - ./logs/symfony:/var/www/symfony/app/logs
@@ -23,8 +21,6 @@ services:
         build: nginx
         ports:
             - 80:80
-        links:
-            - php
         volumes_from:
             - php
         volumes:


### PR DESCRIPTION
Linking containers is obsolete when using version 2 of docker compose. A network will be created between the containers to find each other by it's service name