### PR TITLE
Hotfix/php timezone

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -6,3 +6,6 @@ MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=mydb
 MYSQL_USER=user
 MYSQL_PASSWORD=userpass
+
+# Timezone
+TIMEZONE=Europe/Paris

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
             MYSQL_USER: ${MYSQL_USER}
             MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     php:
-        build: php7-fpm
+        build:
+            context: php7-fpm
+            args:
+                TIMEZONE: ${TIMEZONE}
         volumes:
             - ${SYMFONY_APP_PATH}:/var/www/symfony
             - ./logs/symfony:/var/www/symfony/app/logs

--- a/php7-fpm/Dockerfile
+++ b/php7-fpm/Dockerfile
@@ -12,7 +12,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN composer --version
 
 # Set timezone
-RUN ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime
+ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN "date"
 
 # Type docker-php-ext-install to see available extensions

--- a/php7-fpm/Dockerfile
+++ b/php7-fpm/Dockerfile
@@ -14,6 +14,7 @@ RUN composer --version
 # Set timezone
 ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN printf '[PHP]\ndate.timezone = "%s"\n', $TZ > /usr/local/etc/php/conf.d/tzone.ini
 RUN "date"
 
 # Type docker-php-ext-install to see available extensions

--- a/php7-fpm/Dockerfile
+++ b/php7-fpm/Dockerfile
@@ -12,8 +12,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN composer --version
 
 # Set timezone
-RUN rm /etc/localtime
-RUN ln -s /usr/share/zoneinfo/Europe/Paris /etc/localtime
+RUN ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime
 RUN "date"
 
 # Type docker-php-ext-install to see available extensions

--- a/php7-fpm/Dockerfile
+++ b/php7-fpm/Dockerfile
@@ -1,5 +1,6 @@
 # See https://github.com/docker-library/php/blob/4677ca134fe48d20c820a19becb99198824d78e3/7.0/fpm/Dockerfile
 FROM php:7.0-fpm
+ARG TIMEZONE
 
 MAINTAINER Maxence POUTORD <maxence.poutord@gmail.com>
 
@@ -12,9 +13,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN composer --version
 
 # Set timezone
-ENV TZ=Europe/Paris
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN printf '[PHP]\ndate.timezone = "%s"\n', $TZ > /usr/local/etc/php/conf.d/tzone.ini
+RUN ln -snf /usr/share/zoneinfo/${TIMEZONE} /etc/localtime && echo ${TIMEZONE} > /etc/timezone
+RUN printf '[PHP]\ndate.timezone = "%s"\n', ${TIMEZONE} > /usr/local/etc/php/conf.d/tzone.ini
 RUN "date"
 
 # Type docker-php-ext-install to see available extensions


### PR DESCRIPTION
I make 3 changes here:
- Add `-n` and `-f` options to `ln` to replace an existing directory and an existing symlink automatically, so there is no need to run the `rm` line before creating the symlink.
- As well set the file _/etc/timezone_ in order to support most distros.
- Set the timezone for the PHP/APP level setting. You can see it from the PHP-FPM container's bash with the command `php --info | grep timezone`.