### PR TITLE
Use custom server name

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -9,3 +9,6 @@ MYSQL_PASSWORD=userpass
 
 # Timezone
 TIMEZONE=Europe/Paris
+
+# Server Name
+SERVER_NAME=symfony.dev

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Docker-symfony gives you everything you need for developing Symfony application.
 
     ```bash
     # UNIX only: get containers IP address and update host (replace IP according to your configuration) (on Windows, edit C:\Windows\System32\drivers\etc\hosts)
-    $ sudo echo $(docker network inspect bridge | grep Gateway | grep -o -E '[0-9\.]+') "symfony.dev" >> /etc/hosts
+    $ sudo echo $(docker network inspect bridge | grep Gateway | grep -o -E '[0-9\.]+') "yourservername" >> /etc/hosts
     ```
 
-    **Note:** For **OS X**, please take a look [here](https://docs.docker.com/docker-for-mac/networking/) and for **Windows** read [this](https://docs.docker.com/docker-for-windows/#/step-4-explore-the-application-and-run-examples) (4th step).
+    **Note:** For **OS X**, please take a look [here](https://docs.docker.com/docker-for-mac/networking/), but simply use `127.0.0.1` for IP address and for **Windows** read [this](https://docs.docker.com/docker-for-windows/#/step-4-explore-the-application-and-run-examples) (4th step).
 
 4. Prepare Symfony app
     1. Update app/config/parameters.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
             - ./logs/symfony:/var/www/symfony/app/logs
     nginx:
         build: nginx
+        environment:
+            SERVER_NAME: ${SERVER_NAME}
         ports:
             - 80:80
         volumes_from:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,19 +3,28 @@ FROM debian:jessie
 MAINTAINER Maxence POUTORD <maxence.poutord@gmail.com>
 
 RUN apt-get update && apt-get install -y \
-    nginx
+    software-properties-common wget
 
+# Import openresty key
+RUN wget -qO - https://openresty.org/package/pubkey.gpg | apt-key add -
+
+RUN add-apt-repository -y "deb http://openresty.org/package/debian $(lsb_release -sc) openresty"
+RUN apt-get update
+RUN apt-get install -y openresty
+
+RUN mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled/ /etc/nginx/conf.d
+ADD fastcgi_params /etc/nginx/
+ADD mime.types /etc/nginx/
 ADD nginx.conf /etc/nginx/
 ADD symfony.conf /etc/nginx/sites-available/
 
 RUN ln -s /etc/nginx/sites-available/symfony.conf /etc/nginx/sites-enabled/symfony
-RUN rm /etc/nginx/sites-enabled/default
 
 RUN echo "upstream php-upstream { server php:9000; }" > /etc/nginx/conf.d/upstream.conf
 
 RUN usermod -u 1000 www-data
 
-CMD ["nginx"]
+CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/etc/nginx/nginx.conf"]
 
 EXPOSE 80
 EXPOSE 443

--- a/nginx/fastcgi_params
+++ b/nginx/fastcgi_params
@@ -1,0 +1,24 @@
+fastcgi_param   QUERY_STRING            $query_string;
+fastcgi_param   REQUEST_METHOD          $request_method;
+fastcgi_param   CONTENT_TYPE            $content_type;
+fastcgi_param   CONTENT_LENGTH          $content_length;
+
+fastcgi_param   SCRIPT_FILENAME         $document_root$fastcgi_script_name;
+fastcgi_param   SCRIPT_NAME             $fastcgi_script_name;
+fastcgi_param   PATH_INFO               $fastcgi_path_info;
+fastcgi_param       PATH_TRANSLATED         $document_root$fastcgi_path_info;
+fastcgi_param   REQUEST_URI             $request_uri;
+fastcgi_param   DOCUMENT_URI            $document_uri;
+fastcgi_param   DOCUMENT_ROOT           $document_root;
+fastcgi_param   SERVER_PROTOCOL         $server_protocol;
+
+fastcgi_param   GATEWAY_INTERFACE       CGI/1.1;
+fastcgi_param   SERVER_SOFTWARE         nginx/$nginx_version;
+
+fastcgi_param   REMOTE_ADDR             $remote_addr;
+fastcgi_param   REMOTE_PORT             $remote_port;
+fastcgi_param   SERVER_ADDR             $server_addr;
+fastcgi_param   SERVER_PORT             $server_port;
+fastcgi_param   SERVER_NAME             $server_name;
+
+fastcgi_param   HTTPS                   $https;

--- a/nginx/mime.types
+++ b/nginx/mime.types
@@ -1,0 +1,138 @@
+types {
+
+  # Data interchange
+
+    application/atom+xml                  atom;
+    application/json                      json map topojson;
+    application/ld+json                   jsonld;
+    application/rss+xml                   rss;
+    application/vnd.geo+json              geojson;
+    application/xml                       rdf xml;
+
+
+  # JavaScript
+
+    # Normalize to standard type.
+    # https://tools.ietf.org/html/rfc4329#section-7.2
+    application/javascript                js;
+
+
+  # Manifest files
+
+    application/manifest+json             webmanifest;
+    application/x-web-app-manifest+json   webapp;
+    text/cache-manifest                   appcache;
+
+
+  # Media files
+
+    audio/midi                            mid midi kar;
+    audio/mp4                             aac f4a f4b m4a;
+    audio/mpeg                            mp3;
+    audio/ogg                             oga ogg opus;
+    audio/x-realaudio                     ra;
+    audio/x-wav                           wav;
+    image/bmp                             bmp;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    image/jxr                             jxr hdp wdp;
+    image/png                             png;
+    image/svg+xml                         svg svgz;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/webp                            webp;
+    image/x-jng                           jng;
+    video/3gpp                            3gp 3gpp;
+    video/mp4                             f4p f4v m4v mp4;
+    video/mpeg                            mpeg mpg;
+    video/ogg                             ogv;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asf asx;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+
+    # Serving `.ico` image files with a different media type
+    # prevents Internet Explorer from displaying then as images:
+    # https://github.com/h5bp/html5-boilerplate/commit/37b5fec090d00f38de64b591bcddcb205aadf8ee
+
+    image/x-icon                          cur ico;
+
+
+  # Microsoft Office
+
+    application/msword                                                         doc;
+    application/vnd.ms-excel                                                   xls;
+    application/vnd.ms-powerpoint                                              ppt;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+
+  # Web fonts
+
+    application/font-woff                 woff;
+    application/font-woff2                woff2;
+    application/vnd.ms-fontobject         eot;
+
+    # Browsers usually ignore the font media types and simply sniff
+    # the bytes to figure out the font type.
+    # https://mimesniff.spec.whatwg.org/#matching-a-font-type-pattern
+    #
+    # However, Blink and WebKit based browsers will show a warning
+    # in the console if the following font types are served with any
+    # other media types.
+
+    application/x-font-ttf                ttc ttf;
+    font/opentype                         otf;
+
+
+  # Other
+
+    application/java-archive              ear jar war;
+    application/mac-binhex40              hqx;
+    application/octet-stream              bin deb dll dmg exe img iso msi msm msp safariextz;
+    application/pdf                       pdf;
+    application/postscript                ai eps ps;
+    application/rtf                       rtf;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/vnd.wap.wmlc              wmlc;
+    application/x-7z-compressed           7z;
+    application/x-bb-appworld             bbaw;
+    application/x-bittorrent              torrent;
+    application/x-chrome-extension        crx;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-opera-extension         oex;
+    application/x-perl                    pl pm;
+    application/x-pilot                   pdb prc;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            crt der pem;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xslt+xml                  xsl;
+    application/zip                       zip;
+    text/css                              css;
+    text/csv                              csv;
+    text/html                             htm html shtml;
+    text/markdown                         md;
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vcard                            vcard vcf;
+    text/vnd.rim.location.xloc            xloc;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/vtt                              vtt;
+    text/x-component                      htc;
+
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes 4;
 pid /run/nginx.pid;
+env SERVER_NAME;
 
 events {
   worker_connections  2048;

--- a/nginx/symfony.conf
+++ b/nginx/symfony.conf
@@ -1,5 +1,6 @@
 server {
-    server_name symfony.dev;
+    set_by_lua_block $svr_name { return os.getenv("SERVER_NAME") }
+    server_name $svr_name$1;
     root /var/www/symfony/web;
 
     location / {


### PR DESCRIPTION
Hello,

First, let me thank you for this project.

This PR has the same goal than #68 , meaning using a custom env variable for the server name (for the moment is it `symfony.dev` in the config file)

# Description

Nginx is not supposed to read for env variables, to do so, you need the [Lua support](https://github.com/openresty/lua-nginx-module#readme) through the dedicated module. The recommanded way to use it is to use [openresty](http://openresty.org/en/), which I did in the nginx image

# Usage

A new env variable has been added to the `.env.dist` file, `SERVER_NAME`. You should update this variable to change your server name

# Changes

The nginx service now uses openresty.
Because Openresty does not come with default file, I had to :

- Create dedicated config directories
- Add `fastcgi_params` and `mime.types` files to the project

The env variables is retrieved using the [`set_by_lua_block`](https://github.com/openresty/lua-nginx-module#set_by_lua_block) directive, using this simple block :

```lua
return os.getenv("SERVER_NAME")
```

# Related Issue

Fix #58 

# Misc

This PR has been tested with [this demo app](https://github.com/auth0-blog/symfony-got), which is in 3.1, and an internal application (not from auth0), which is in 3.3 .

The applications have been tested both on Mac OS X and Ubuntu.


Thank you for reading 😄 