### PR TITLE
Change default domain name to symfony.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Docker-symfony gives you everything you need for developing Symfony application.
     $ docker-compose up -d
     ```
 
-3. Update your system host file (add symfony.dev)
+3. Update your system host file (add symfony.local)
 
     ```bash
     # UNIX only: get containers IP address and update host (replace IP according to your configuration) (on Windows, edit C:\Windows\System32\drivers\etc\hosts)
-    $ sudo echo $(docker network inspect bridge | grep Gateway | grep -o -E '[0-9\.]+') "symfony.dev" >> /etc/hosts
+    $ sudo echo $(docker network inspect bridge | grep Gateway | grep -o -E '[0-9\.]+') "symfony.local" >> /etc/hosts
     ```
 
     **Note:** For **OS X**, please take a look [here](https://docs.docker.com/docker-for-mac/networking/) and for **Windows** read [this](https://docs.docker.com/docker-for-windows/#/step-4-explore-the-application-and-run-examples) (4th step).
@@ -63,9 +63,9 @@ Docker-symfony gives you everything you need for developing Symfony application.
 
 Just run `docker-compose up -d`, then:
 
-* Symfony app: visit [symfony.dev](http://symfony.dev)  
-* Symfony dev mode: visit [symfony.dev/app_dev.php](http://symfony.dev/app_dev.php)  
-* Logs (Kibana): [symfony.dev:81](http://symfony.dev:81)
+* Symfony app: visit [symfony.local](http://symfony.local)  
+* Symfony dev mode: visit [symfony.local/app_dev.php](http://symfony.local/app_dev.php)  
+* Logs (Kibana): [symfony.local:81](http://symfony.local:81)
 * Logs (files location): logs/nginx and logs/symfony
 
 ## Customize

--- a/doc/custom.md
+++ b/doc/custom.md
@@ -16,7 +16,7 @@
                 - "8080:80"
     ```
 
-2. Visit: [symfony.dev:8080](http://symfony.dev:8080)
+2. Visit: [symfony.local:8080](http://symfony.local:8080)
 
 ## Add Redis
 

--- a/nginx/symfony.conf
+++ b/nginx/symfony.conf
@@ -1,5 +1,5 @@
 server {
-    server_name symfony.dev;
+    server_name symfony.local;
     root /var/www/symfony/web;
 
     location / {


### PR DESCRIPTION
Due to the newest Chrome forces https on .dev domains, I will suggest change default domain to symfony.local

More in article:
[https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/](https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/)