### PR TITLE
Make Nginx use Symfony as default server

### DIFF
--- a/nginx/symfony.conf
+++ b/nginx/symfony.conf
@@ -1,5 +1,5 @@
 server {
-    server_name symfony.local;
+    server_name _;
     root /var/www/symfony/web;
 
     location / {


### PR DESCRIPTION
Makes Nginx respond always as if one asks for `symfony.local`, so you can use any hostname as long as the request ends up on this container.